### PR TITLE
Add null check for the current user

### DIFF
--- a/src/Pages/MemberProfilePage.php
+++ b/src/Pages/MemberProfilePage.php
@@ -181,6 +181,7 @@ class MemberProfilePage extends Page
     public function Link($action = null)
     {
         if (!$action
+            && Security::getCurrentUser()
             && Security::getCurrentUser()->ID
             && !$this->AllowProfileEditing
             && $this->CanAddMembers()


### PR DESCRIPTION
Since the MemberProfilePage acts as a registration page, possible null exception when the current user is null